### PR TITLE
Issue09

### DIFF
--- a/src/kqueue/kqueue.cpp
+++ b/src/kqueue/kqueue.cpp
@@ -1,0 +1,17 @@
+#include <sys/event.h>
+
+#include <cstddef>
+
+namespace util {
+
+inline ssize_t kevent_ctl(int kq, const struct kevent *changelist, int nchangs,
+                          const struct timespec *timeout) {
+  return kevent(kq, changelist, nchangs, NULL, 0, timeout);
+}
+
+inline ssize_t kevent_wait(int kq, struct kevent *eventlist, int nevents,
+                           const struct timespec *timeout) {
+  return kevent(kq, NULL, 0, eventlist, nevents, timeout);
+}
+
+}  // namespace util

--- a/src/kqueue/kqueue.hpp
+++ b/src/kqueue/kqueue.hpp
@@ -1,0 +1,34 @@
+#ifndef KQUEUE_KQUEUE_HPP
+#define KQUEUE_KQUEUE_HPP
+
+#include <sys/event.h>
+
+#ifdef EV_SET
+#undef EV_SET
+// 조금 더 나은 인텔리센스 지원을 위해서 새로 정의함
+#define EV_SET(kev, ident, filter, flags, fflags, data, udata) \
+  do {                                                         \
+    struct kevent *__kevp__ = (kev);                           \
+    __kevp__->ident = (ident);                                 \
+    __kevp__->filter = (filter);                               \
+    __kevp__->flags = (flags);                                 \
+    __kevp__->fflags = (fflags);                               \
+    __kevp__->data = (data);                                   \
+    __kevp__->udata = (udata);                                 \
+  } while (0)
+#endif  // EV_SET
+
+namespace util {
+
+inline ssize_t kevent_ctl(int kq, const struct kevent *changelist, int nchangs,
+                          const struct timespec *timeout);
+
+inline ssize_t kevent_wait(int kq, struct kevent *eventlist, int nevents,
+                           const struct timespec *timeout);
+
+using ::kevent;
+using ::kqueue;
+
+}  // namespace util
+
+#endif  // KQUEUE_KQUEUE_HPP

--- a/src/socket/socket.cpp
+++ b/src/socket/socket.cpp
@@ -1,0 +1,33 @@
+#include <arpa/inet.h>
+#include <sys/socket.h>
+
+namespace util {
+
+inline int socket(int domain, int type, int protocol) {
+  return ::socket(domain, type, protocol);
+}
+
+inline int listen(int socket, int backlog) {
+  return ::listen(socket, backlog);
+}
+
+inline int bind_in(int socket, const struct sockaddr_in *addr) {
+  return ::bind(socket, reinterpret_cast<const sockaddr *>(addr),
+                sizeof(*addr));
+}
+
+inline int connect_in(int socket, const struct sockaddr_in *addr) {
+  return ::connect(socket, reinterpret_cast<const sockaddr *>(addr),
+                   sizeof(*addr));
+}
+
+inline ssize_t recv(int socket, void *buffer, size_t length, int flags) {
+  return ::recv(socket, buffer, length, flags);
+}
+
+inline ssize_t send(int socket, const void *buffer, size_t length,
+                    int flags) {
+  return ::send(socket, buffer, length, flags);
+}
+
+}  // namespace util

--- a/src/socket/socket.hpp
+++ b/src/socket/socket.hpp
@@ -1,13 +1,6 @@
 #ifndef SOCKET_SOCKET_HPP
 #define SOCKET_SOCKET_HPP
 
-/**
- * send
- * listen
- *
- *
- */
-
 #include <sys/socket.h>
 
 namespace util {

--- a/src/socket/socket.hpp
+++ b/src/socket/socket.hpp
@@ -2,6 +2,7 @@
 #define SOCKET_SOCKET_HPP
 
 #include <sys/socket.h>
+#include <arpa/inet.h>
 
 namespace util {
 

--- a/src/socket/socket.hpp
+++ b/src/socket/socket.hpp
@@ -1,0 +1,29 @@
+#ifndef SOCKET_SOCKET_HPP
+#define SOCKET_SOCKET_HPP
+
+/**
+ * send
+ * listen
+ *
+ *
+ */
+
+#include <sys/socket.h>
+
+namespace util {
+
+using ::accept;
+using ::bind;
+using ::connect;
+
+inline int socket(int domain, int type, int protocol);
+inline int listen(int socket, int backlog);
+inline int bind_in(int socket, const struct sockaddr_in *addr);
+inline int connect_in(int socket, const struct sockaddr_in *addr);
+inline ssize_t recv(int socket, void *buffer, size_t length, int flags = 0);
+inline ssize_t send(int socket, const void *buffer, size_t length,
+                    int flags = 0);
+
+}  // namespace util
+
+#endif  // SOCKET_SOCKET_HPP


### PR DESCRIPTION
## 개요

<!--
풀 리퀘스트에 이슈 연결하기
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- Fixes #102
- Resolved #101
-->

- Resolved #9

## 설명

<!--
무엇이 변했는지 적기
-->

- struct sockaddr* 을 받는 함수에 struct socketaddr_in을 넣었을 때 생기는 reinterpret_cast을 없애고 특화 함수로 따로 만듬
- 거의 0을 넣고 사용하는 flag 인자를 default 인자로 0을 넣게 개선
- 단순히 socket(int, int, int) / EV_SET(ev, a, b, c, d, e, f) 같이 사용할 때 인자 순서를 알기 힘든 함수들 개선
- 두가지 역할을 하는 kevent함수를 kevent_ctl / kevent_wait으로 linux의 epoll스타일로 쪼갬
- namespace util
