### PR TITLE
문자열 포매팅 기능 추가하기

### DIFF
--- a/container_of.py
+++ b/container_of.py
@@ -6,7 +6,7 @@ container_of.py:
     example usage - "container_of<vector<string> >("a", "b", "c)"
 
 usage:
-    create.py [--help] [options] (--dry | <path>)
+    container_of.py [--help] [options] (--dry | <path>)
 
 options:
     -h, --help            show this help message and exit
@@ -110,12 +110,12 @@ def main():
     # print(args)
 
     size = int(args["--size"])
-    path = Path(args["<path>"]) or None
+    path = Path(args["<path>"]) if args["<path>"] else None
     text = create_formatted_result(size, path)
 
     if args["--dry"]:
         print(text)
-    else:
+    elif path is not None:
         path.write_text(text)
 
 

--- a/src/util/strutil/format.cpp
+++ b/src/util/strutil/format.cpp
@@ -1,0 +1,49 @@
+#include <util/strutil/strutil.hpp>
+#include <vector>
+
+namespace util {
+using std::string;
+using std::vector;
+
+string format(const string& fmt, const vector<string>& args) {
+  int arg_counter = 0;
+  std::string result;
+
+  for (size_t i = 0; i < fmt.size(); i++) {
+    if (fmt[i] == '{') {
+      if (fmt[i + 1] == '{') {
+        result += '{';
+        i++;
+      } else {
+        result += args.at(arg_counter++);
+        size_t j = i + 1;
+        for (; j < fmt.size(); j++) {
+          if (fmt[j] == '{') {
+            throw std::runtime_error("unmatched opening brace at " +
+                                     util::to_string(j));
+          } else if (fmt[j] == '}') {
+            i = j;
+            break;
+          }
+        }
+        if (j == fmt.size()) {
+          throw std::runtime_error(
+              "missing closing brace '}' at end of format string");
+        }
+      }
+    } else if (fmt[i] == '}') {
+      if (fmt[i + 1] == '}') {
+        result += '}';
+        i++;
+      } else {
+        throw std::runtime_error("unmatched closing brace at " +
+                                 util::to_string(i));
+      }
+    } else {
+      result += fmt[i];
+    }
+  }
+  return result;
+}
+
+}  // namespace util

--- a/src/util/strutil/format.cpp
+++ b/src/util/strutil/format.cpp
@@ -5,6 +5,13 @@ namespace util {
 using std::string;
 using std::vector;
 
+/**
+ * @brief 파이썬 str.format() 또는 c++20 스타일 문자열 포매팅.
+ *
+ * @param fmt 문자열 포매팅 형식. 중괄호 "{}" 안의 값은 무시됨.
+ *            중괄호 자체를 쓰려면 "{{" 또는 "}}" 쓰기.
+ * @param args 치환에 사용될 문자열의 배열.
+ */
 class FormatState {
  private:
   string fmt;
@@ -25,8 +32,8 @@ class FormatState {
       } else if (on_escaped_bracket("}}")) {
         advance_and_append("}");
       } else if (on_char('}')) {
-        throw std::runtime_error("unmatched closing brace at " +
-                                 util::to_string(curs));
+        throw std::invalid_argument("unmatched closing brace at " +
+                                    to_string(curs));
       } else {
         result += fmt[curs];
       }
@@ -34,7 +41,7 @@ class FormatState {
   }
 
   // 멤버 함수
-  bool on_char(const char c) { return (fmt[curs] == c); }
+  bool on_char(const char c) const { return (fmt[curs] == c); }
 
   bool on_escaped_bracket(const string& match) {
     return fmt.substr(curs, 2) == match;
@@ -49,17 +56,18 @@ class FormatState {
     result += args.at(arg_index++);
     for (size_t i = curs + 1; i < fmt.size(); i++) {
       if (fmt[i] == '{') {
-        throw std::runtime_error("unmatched opening brace at " + to_string(i));
+        throw std::invalid_argument("unmatched opening brace at " +
+                                    to_string(i));
       } else if (fmt[i] == '}') {
         curs = i;
         return;
       }
     }
-    throw std::runtime_error(
+    throw std::invalid_argument(
         "missing closing brace '}' at end of format string");
   }
 
-  operator string() { return result; }
+  operator string() const { return result; }
 };
 
 string format(const string& fmt, const vector<string>& args) {

--- a/src/util/strutil/format.cpp
+++ b/src/util/strutil/format.cpp
@@ -5,73 +5,54 @@ namespace util {
 using std::string;
 using std::vector;
 
-/**
- * @brief 파이썬 str.format() 또는 c++20 스타일 문자열 포매팅.
- *
- * @param fmt 문자열 포매팅 형식. 중괄호 "{}" 안의 값은 무시됨.
- *            중괄호 자체를 쓰려면 "{{" 또는 "}}" 쓰기.
- * @param args 치환에 사용될 문자열의 배열.
- */
-class FormatState {
- private:
-  string fmt;
-  vector<string> args;
-  std::string result;
-  int arg_index;
-  size_t curs;
-
- public:
-  // 생성자
-  FormatState(const string& fmt, const vector<string>& args)
-      : fmt(fmt), args(args), arg_index(0), curs(0) {
-    for (; curs < fmt.size(); curs++) {
-      if (on_escaped_bracket("{{")) {
-        advance_and_append("{");
-      } else if (on_char('{')) {
-        advance_to_closing_bracket();
-      } else if (on_escaped_bracket("}}")) {
-        advance_and_append("}");
-      } else if (on_char('}')) {
-        throw std::invalid_argument("unmatched closing brace at " +
-                                    to_string(curs));
-      } else {
-        result += fmt[curs];
-      }
+format::format(const string& fmt, const vector<string>& args)
+    : fmt(fmt), args(args), arg_index(0), curs(0) {
+  for (; curs < fmt.size(); curs++) {
+    if (on_escaped_bracket("{{")) {
+      advance_and_append("{");
+    } else if (on_char('{')) {
+      advance_to_closing_bracket();
+    } else if (on_escaped_bracket("}}")) {
+      advance_and_append("}");
+    } else if (on_char('}')) {
+      throw std::invalid_argument("unmatched closing brace at " +
+                                  to_string(curs));
+    } else {
+      result += fmt[curs];
     }
   }
+}
 
-  // 멤버 함수
-  bool on_char(const char c) const { return (fmt[curs] == c); }
+bool format::on_char(const char c) const { return (fmt[curs] == c); }
 
-  bool on_escaped_bracket(const string& match) {
-    return fmt.substr(curs, 2) == match;
-  }
+bool format::on_escaped_bracket(const string& match) {
+  return fmt.substr(curs, 2) == match;
+}
 
-  void advance_and_append(const string& to_add) {
-    curs++;
-    result += to_add;
-  }
+void format::advance_and_append(const string& to_add) {
+  curs++;
+  result += to_add;
+}
 
-  void advance_to_closing_bracket() {
-    result += args.at(arg_index++);
-    for (size_t i = curs + 1; i < fmt.size(); i++) {
-      if (fmt[i] == '{') {
-        throw std::invalid_argument("unmatched opening brace at " +
-                                    to_string(i));
-      } else if (fmt[i] == '}') {
-        curs = i;
-        return;
-      }
+void format::advance_to_closing_bracket() {
+  result += args.at(arg_index++);
+  for (size_t i = curs + 1; i < fmt.size(); i++) {
+    if (fmt[i] == '{') {
+      throw std::invalid_argument("unmatched opening brace at " + to_string(i));
+    } else if (fmt[i] == '}') {
+      curs = i;
+      return;
     }
-    throw std::invalid_argument(
-        "missing closing brace '}' at end of format string");
   }
+  throw std::invalid_argument(
+      "missing closing brace '}' at end of format string");
+}
 
-  operator string() const { return result; }
-};
+string format::str() const { return result; }
+format::operator string() const { return result; }
 
-string format(const string& fmt, const vector<string>& args) {
-  return FormatState(fmt, args);
+std::ostream& operator<<(std::ostream& os, const format& f) {
+  return os << static_cast<string>(f);
 }
 
 }  // namespace util

--- a/src/util/strutil/format.cpp
+++ b/src/util/strutil/format.cpp
@@ -17,7 +17,7 @@ struct FormatState {
 
   // 멤버 함수
   bool on_escape(size_t i, const string& match) {
-    return fmt.substr(i, i + 1) == match;
+    return fmt.substr(i, 2) == match;
   }
   void advance_and_append(size_t& i, const string& to_add) {
     i++;
@@ -27,8 +27,8 @@ struct FormatState {
 
 string format(const string& fmt, const vector<string>& args) {
   FormatState state(fmt, args);
-
-  for (size_t i = 0; i < fmt.size(); i++) {
+  size_t i = 0;
+  for (; i < fmt.size(); i++) {
     if (state.on_escape(i, "{{")) {
       state.advance_and_append(i, "{");
     } else if (fmt[i] == '{') {

--- a/src/util/strutil/format.cpp
+++ b/src/util/strutil/format.cpp
@@ -16,38 +16,43 @@ struct FormatState {
       : fmt(fmt), args(args), arg_counter(0) {}
 
   // 멤버 함수
-  bool on_escape(size_t i, const string& match) {
+  bool on_escaped_bracket(size_t i, const string& match) {
     return fmt.substr(i, 2) == match;
   }
+
   void advance_and_append(size_t& i, const string& to_add) {
     i++;
     result += to_add;
+  }
+
+  void advance_to_closing_bracket(size_t& i) {
+    result += args.at(arg_counter++);
+    size_t j = i + 1;
+    for (; j < fmt.size(); j++) {
+      if (fmt[j] == '{') {
+        throw std::runtime_error("unmatched opening brace at " +
+                                 util::to_string(j));
+      } else if (fmt[j] == '}') {
+        i = j;
+        break;
+      }
+    }
+    if (j == fmt.size()) {
+      throw std::runtime_error(
+          "missing closing brace '}' at end of format string");
+    }
   }
 };
 
 string format(const string& fmt, const vector<string>& args) {
   FormatState state(fmt, args);
-  size_t i = 0;
-  for (; i < fmt.size(); i++) {
-    if (state.on_escape(i, "{{")) {
+
+  for (size_t i = 0; i < fmt.size(); i++) {
+    if (state.on_escaped_bracket(i, "{{")) {
       state.advance_and_append(i, "{");
     } else if (fmt[i] == '{') {
-      state.result += args.at(state.arg_counter++);
-      size_t j = i + 1;
-      for (; j < fmt.size(); j++) {
-        if (fmt[j] == '{') {
-          throw std::runtime_error("unmatched opening brace at " +
-                                   util::to_string(j));
-        } else if (fmt[j] == '}') {
-          i = j;
-          break;
-        }
-      }
-      if (j == fmt.size()) {
-        throw std::runtime_error(
-            "missing closing brace '}' at end of format string");
-      }
-    } else if (state.on_escape(i, "}}")) {
+      state.advance_to_closing_bracket(i);
+    } else if (state.on_escaped_bracket(i, "}}")) {
       state.advance_and_append(i, "}");
     } else if (fmt[i] == '}') {
       throw std::runtime_error("unmatched closing brace at " +

--- a/src/util/strutil/format.cpp
+++ b/src/util/strutil/format.cpp
@@ -5,45 +5,50 @@ namespace util {
 using std::string;
 using std::vector;
 
-string format(const string& fmt, const vector<string>& args) {
-  int arg_counter = 0;
+struct FormatState {
+  string fmt;
+  vector<string> args;
   std::string result;
+  int arg_counter;
+
+  FormatState(const string& fmt, const vector<string>& args)
+      : fmt(fmt), args(args), arg_counter(0) {}
+};
+
+string format(const string& fmt, const vector<string>& args) {
+  FormatState state(fmt, args);
 
   for (size_t i = 0; i < fmt.size(); i++) {
-    if (fmt[i] == '{') {
-      if (fmt[i + 1] == '{') {
-        result += '{';
-        i++;
-      } else {
-        result += args.at(arg_counter++);
-        size_t j = i + 1;
-        for (; j < fmt.size(); j++) {
-          if (fmt[j] == '{') {
-            throw std::runtime_error("unmatched opening brace at " +
-                                     util::to_string(j));
-          } else if (fmt[j] == '}') {
-            i = j;
-            break;
-          }
-        }
-        if (j == fmt.size()) {
-          throw std::runtime_error(
-              "missing closing brace '}' at end of format string");
+    if (fmt.substr(i, i + 1) == "{{") {
+      state.result += '{';
+      i++;
+    } else if (fmt[i] == '{') {
+      state.result += args.at(state.arg_counter++);
+      size_t j = i + 1;
+      for (; j < fmt.size(); j++) {
+        if (fmt[j] == '{') {
+          throw std::runtime_error("unmatched opening brace at " +
+                                   util::to_string(j));
+        } else if (fmt[j] == '}') {
+          i = j;
+          break;
         }
       }
+      if (j == fmt.size()) {
+        throw std::runtime_error(
+            "missing closing brace '}' at end of format string");
+      }
+    } else if (fmt.substr(i, i + 1) == "}}") {
+      state.result += '}';
+      i++;
     } else if (fmt[i] == '}') {
-      if (fmt[i + 1] == '}') {
-        result += '}';
-        i++;
-      } else {
-        throw std::runtime_error("unmatched closing brace at " +
-                                 util::to_string(i));
-      }
+      throw std::runtime_error("unmatched closing brace at " +
+                               util::to_string(i));
     } else {
-      result += fmt[i];
+      state.result += fmt[i];
     }
   }
-  return result;
+  return state.result;
 }
 
 }  // namespace util

--- a/src/util/strutil/format.cpp
+++ b/src/util/strutil/format.cpp
@@ -11,17 +11,26 @@ struct FormatState {
   std::string result;
   int arg_counter;
 
+  // 생성자
   FormatState(const string& fmt, const vector<string>& args)
       : fmt(fmt), args(args), arg_counter(0) {}
+
+  // 멤버 함수
+  bool on_escape(size_t i, const string& match) {
+    return fmt.substr(i, i + 1) == match;
+  }
+  void advance_and_append(size_t& i, const string& to_add) {
+    i++;
+    result += to_add;
+  }
 };
 
 string format(const string& fmt, const vector<string>& args) {
   FormatState state(fmt, args);
 
   for (size_t i = 0; i < fmt.size(); i++) {
-    if (fmt.substr(i, i + 1) == "{{") {
-      state.result += '{';
-      i++;
+    if (state.on_escape(i, "{{")) {
+      state.advance_and_append(i, "{");
     } else if (fmt[i] == '{') {
       state.result += args.at(state.arg_counter++);
       size_t j = i + 1;
@@ -38,9 +47,8 @@ string format(const string& fmt, const vector<string>& args) {
         throw std::runtime_error(
             "missing closing brace '}' at end of format string");
       }
-    } else if (fmt.substr(i, i + 1) == "}}") {
-      state.result += '}';
-      i++;
+    } else if (state.on_escape(i, "}}")) {
+      state.advance_and_append(i, "}");
     } else if (fmt[i] == '}') {
       throw std::runtime_error("unmatched closing brace at " +
                                util::to_string(i));

--- a/src/util/strutil/format.cpp
+++ b/src/util/strutil/format.cpp
@@ -34,13 +34,28 @@ void format::advance_and_append(const string& to_add) {
   result += to_add;
 }
 
-void format::advance_to_closing_bracket() {
+void format::insert_arg() {
+  if (arg_index >= args.size())
+    throw std::invalid_argument(
+        "positional argument index out of range, expected at least " +
+        to_string(arg_index + 1) + " arguments but got " +
+        to_string(args.size()));
   result += args.at(arg_index++);
+}
+
+void format::insert_arg(size_t index) {
+  if (index >= args.size())
+    throw std::invalid_argument("index out of range: " + to_string(index));
+  result += args[index];
+}
+
+void format::advance_to_closing_bracket() {
   for (size_t i = curs + 1; i < fmt.size(); i++) {
     if (fmt[i] == '{') {
       throw std::invalid_argument("unmatched opening brace at " + to_string(i));
     } else if (fmt[i] == '}') {
       curs = i;
+      insert_arg();
       return;
     }
   }

--- a/src/util/strutil/format.cpp
+++ b/src/util/strutil/format.cpp
@@ -5,63 +5,65 @@ namespace util {
 using std::string;
 using std::vector;
 
-struct FormatState {
+class FormatState {
+ private:
   string fmt;
   vector<string> args;
   std::string result;
-  int arg_counter;
+  int arg_index;
+  size_t curs;
 
+ public:
   // 생성자
   FormatState(const string& fmt, const vector<string>& args)
-      : fmt(fmt), args(args), arg_counter(0) {}
-
-  // 멤버 함수
-  bool on_escaped_bracket(size_t i, const string& match) {
-    return fmt.substr(i, 2) == match;
+      : fmt(fmt), args(args), arg_index(0), curs(0) {
+    for (; curs < fmt.size(); curs++) {
+      if (on_escaped_bracket("{{")) {
+        advance_and_append("{");
+      } else if (on_char('{')) {
+        advance_to_closing_bracket();
+      } else if (on_escaped_bracket("}}")) {
+        advance_and_append("}");
+      } else if (on_char('}')) {
+        throw std::runtime_error("unmatched closing brace at " +
+                                 util::to_string(curs));
+      } else {
+        result += fmt[curs];
+      }
+    }
   }
 
-  void advance_and_append(size_t& i, const string& to_add) {
-    i++;
+  // 멤버 함수
+  bool on_char(const char c) { return (fmt[curs] == c); }
+
+  bool on_escaped_bracket(const string& match) {
+    return fmt.substr(curs, 2) == match;
+  }
+
+  void advance_and_append(const string& to_add) {
+    curs++;
     result += to_add;
   }
 
-  void advance_to_closing_bracket(size_t& i) {
-    result += args.at(arg_counter++);
-    size_t j = i + 1;
-    for (; j < fmt.size(); j++) {
-      if (fmt[j] == '{') {
-        throw std::runtime_error("unmatched opening brace at " +
-                                 util::to_string(j));
-      } else if (fmt[j] == '}') {
-        i = j;
-        break;
+  void advance_to_closing_bracket() {
+    result += args.at(arg_index++);
+    for (size_t i = curs + 1; i < fmt.size(); i++) {
+      if (fmt[i] == '{') {
+        throw std::runtime_error("unmatched opening brace at " + to_string(i));
+      } else if (fmt[i] == '}') {
+        curs = i;
+        return;
       }
     }
-    if (j == fmt.size()) {
-      throw std::runtime_error(
-          "missing closing brace '}' at end of format string");
-    }
+    throw std::runtime_error(
+        "missing closing brace '}' at end of format string");
   }
+
+  operator string() { return result; }
 };
 
 string format(const string& fmt, const vector<string>& args) {
-  FormatState state(fmt, args);
-
-  for (size_t i = 0; i < fmt.size(); i++) {
-    if (state.on_escaped_bracket(i, "{{")) {
-      state.advance_and_append(i, "{");
-    } else if (fmt[i] == '{') {
-      state.advance_to_closing_bracket(i);
-    } else if (state.on_escaped_bracket(i, "}}")) {
-      state.advance_and_append(i, "}");
-    } else if (fmt[i] == '}') {
-      throw std::runtime_error("unmatched closing brace at " +
-                               util::to_string(i));
-    } else {
-      state.result += fmt[i];
-    }
-  }
-  return state.result;
+  return FormatState(fmt, args);
 }
 
 }  // namespace util

--- a/src/util/strutil/strutil.hpp
+++ b/src/util/strutil/strutil.hpp
@@ -73,7 +73,28 @@ void print_vector(vector<T> v, bool oneline = true) {
  * @param args 포매팅에 사용할 변수 목록
  */
 // TODO: {0}, {1} 등의 순서 지원
-string format(const string& fmt, const vector<string>& args);
+class format {
+ private:
+  string fmt;
+  vector<string> args;
+  std::string result;
+  int arg_index;
+  size_t curs;
+
+ private:
+  bool on_char(const char c) const;
+  bool on_escaped_bracket(const string& match);
+  void advance_and_append(const string& to_add);
+  void advance_to_closing_bracket();
+
+ public:
+  format(const string& fmt, const vector<string>& args);
+
+  string str() const;
+  operator string() const;
+};
+
+std::ostream& operator<<(std::ostream& os, const format& f);
 
 }  // namespace util
 

--- a/src/util/strutil/strutil.hpp
+++ b/src/util/strutil/strutil.hpp
@@ -6,6 +6,10 @@
 #include <string>
 #include <vector>
 
+#include "util/strutil/vec_of_any.hpp"
+
+#define FMT(fmt, param) util::format(fmt, VA(param))
+
 namespace util {
 
 using std::string;
@@ -57,6 +61,19 @@ void print_vector(vector<T> v, bool oneline = true) {
   }
   std::cout << "\n";
 }
+
+/**
+ * @brief 파이썬 str.format()과 비슷한 문자열 포매팅
+ *
+ * 중괄호 한 쌍마다 args의 인자 하나로 치환됨
+ * util::format("{} {foo} {{bar}}", V(("hello", "world")))
+ * -> "hello world {{bar}}"
+ *
+ * @param fmt 문자열 포매팅 형식. 중괄호 이스케이핑: "{{", "}}"
+ * @param args 포매팅에 사용할 변수 목록
+ */
+// TODO: {0}, {1} 등의 순서 지원
+string format(const string& fmt, const vector<string>& args);
 
 }  // namespace util
 

--- a/src/util/strutil/strutil.hpp
+++ b/src/util/strutil/strutil.hpp
@@ -78,7 +78,7 @@ class format {
   string fmt;
   vector<string> args;
   std::string result;
-  int arg_index;
+  size_t arg_index;
   size_t curs;
 
  private:
@@ -86,6 +86,8 @@ class format {
   bool on_escaped_bracket(const string& match);
   void advance_and_append(const string& to_add);
   void advance_to_closing_bracket();
+  void insert_arg();  //< 인자 삽입후 다음 인자로 이동
+  void insert_arg(size_t index); //< 인덱스의 인자 삽입 후 이동 없음
 
  public:
   format(const string& fmt, const vector<string>& args);

--- a/src/util/strutil/vec_of_any.hpp
+++ b/src/util/strutil/vec_of_any.hpp
@@ -1,0 +1,99 @@
+#ifndef SRC_UTIL_STRUTIL_VEC_OF_ANY_HPP
+#define SRC_UTIL_STRUTIL_VEC_OF_ANY_HPP
+
+// do not try to directly edit this file.
+// generate using vec_of_any.py instead
+#include <sstream>
+
+#define VA(param) util::vec_of_any param
+
+namespace util {
+
+using std::string;
+using std::stringstream;
+using std::vector;
+
+template <typename T>
+static string s(T t) {
+  stringstream ss;
+  ss << t;
+  return ss.str();
+}
+
+inline vector<string> vec_of_any() { return vector<string>(); }
+
+template <class T0>
+inline vector<string> vec_of_any(T0 arg0) {
+  const string args[1] = {s(arg0)};
+  return vector<string>(args, args + 1);
+}
+
+template <class T0, class T1>
+inline vector<string> vec_of_any(T0 arg0, T1 arg1) {
+  const string args[2] = {s(arg0), s(arg1)};
+  return vector<string>(args, args + 2);
+}
+
+template <class T0, class T1, class T2>
+inline vector<string> vec_of_any(T0 arg0, T1 arg1, T2 arg2) {
+  const string args[3] = {s(arg0), s(arg1), s(arg2)};
+  return vector<string>(args, args + 3);
+}
+
+template <class T0, class T1, class T2, class T3>
+inline vector<string> vec_of_any(T0 arg0, T1 arg1, T2 arg2, T3 arg3) {
+  const string args[4] = {s(arg0), s(arg1), s(arg2), s(arg3)};
+  return vector<string>(args, args + 4);
+}
+
+template <class T0, class T1, class T2, class T3, class T4>
+inline vector<string> vec_of_any(T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4) {
+  const string args[5] = {s(arg0), s(arg1), s(arg2), s(arg3), s(arg4)};
+  return vector<string>(args, args + 5);
+}
+
+template <class T0, class T1, class T2, class T3, class T4, class T5>
+inline vector<string> vec_of_any(T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4,
+                                 T5 arg5) {
+  const string args[6] = {s(arg0), s(arg1), s(arg2), s(arg3), s(arg4), s(arg5)};
+  return vector<string>(args, args + 6);
+}
+
+template <class T0, class T1, class T2, class T3, class T4, class T5, class T6>
+inline vector<string> vec_of_any(T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4,
+                                 T5 arg5, T6 arg6) {
+  const string args[7] = {s(arg0), s(arg1), s(arg2), s(arg3),
+                          s(arg4), s(arg5), s(arg6)};
+  return vector<string>(args, args + 7);
+}
+
+template <class T0, class T1, class T2, class T3, class T4, class T5, class T6,
+          class T7>
+inline vector<string> vec_of_any(T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4,
+                                 T5 arg5, T6 arg6, T7 arg7) {
+  const string args[8] = {s(arg0), s(arg1), s(arg2), s(arg3),
+                          s(arg4), s(arg5), s(arg6), s(arg7)};
+  return vector<string>(args, args + 8);
+}
+
+template <class T0, class T1, class T2, class T3, class T4, class T5, class T6,
+          class T7, class T8>
+inline vector<string> vec_of_any(T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4,
+                                 T5 arg5, T6 arg6, T7 arg7, T8 arg8) {
+  const string args[9] = {s(arg0), s(arg1), s(arg2), s(arg3), s(arg4),
+                          s(arg5), s(arg6), s(arg7), s(arg8)};
+  return vector<string>(args, args + 9);
+}
+
+template <class T0, class T1, class T2, class T3, class T4, class T5, class T6,
+          class T7, class T8, class T9>
+inline vector<string> vec_of_any(T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4,
+                                 T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9) {
+  const string args[10] = {s(arg0), s(arg1), s(arg2), s(arg3), s(arg4),
+                           s(arg5), s(arg6), s(arg7), s(arg8), s(arg9)};
+  return vector<string>(args, args + 10);
+}
+
+}  // namespace util
+
+#endif  // SRC_UTIL_STRUTIL_VEC_OF_ANY_HPP

--- a/test/.vscode/c_cpp_properties.json
+++ b/test/.vscode/c_cpp_properties.json
@@ -28,7 +28,8 @@
         "/Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk//System/Library/Frameworks"
       ],
       "compilerPath": "/usr/bin/clang",
-      "intelliSenseMode": "macos-clang-x64"
+      "intelliSenseMode": "macos-clang-x64",
+      "cppStandard": "c++20"
     }
   ],
   "version": 4

--- a/vec_of_any.py
+++ b/vec_of_any.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""
+vec_of_any.py:
+    creates boilerplate for variable argument function "vec_of_any()".
+    vec_of_any generates anonymous string vector, with maximum <size> of
+    different types of arguments, at the cost of being even more verbose.
+    example usage - "vec_of_any(3, "b", 2.0f)
+
+usage:
+    vec_of_any.py [--help] [options] (--dry | <path>)
+
+options:
+    -h, --help            show this help message and exit
+    -n <N>, --size <N>    number of maximum argument size. [default: 10]
+    -d, --dry             write to stdout instead of file.
+"""
+
+import shutil
+from dataclasses import dataclass
+from functools import cached_property
+from pathlib import Path
+from textwrap import dedent
+
+from cpputil import clang_format
+from create import wrap_header
+
+template = dedent(
+    """\
+    // do not try to directly edit this file.
+    // generate using vec_of_any.py instead
+    #include <sstream>
+
+    #define VA(param) util::vec_of_any param
+
+    namespace util {{
+
+    using std::string;
+    using std::vector;
+    using std::stringstream;
+
+    template <typename T>
+    static string s(T t) {{
+        stringstream ss;
+        ss << t;
+        return ss.str();
+    }}
+
+    {text}
+    }} // namespace util
+    """
+)
+
+
+@dataclass
+class Template:
+    size: int = 10
+
+    def maybe(self, then: str) -> str:
+        return "" if self.size == 0 else then
+
+    def create_template_args(self) -> str:
+        args = ", ".join(f"class T{n}" for n in range(self.size))
+        return self.maybe(f"template <{args}>")
+
+    def create_args(self, *, with_type: bool = False) -> str:
+        arg = "T{n} arg{n}" if with_type else "s(arg{n})"
+        return self.maybe(
+            ", ".join([arg.format(n=n) for n in range(self.size)])
+        )
+
+    def create_args_array(self) -> str:
+        return self.maybe(
+            f"const string args[{self.size}] = {{{self.create_args()}}};"
+        )
+
+    def create_return(self) -> str:
+        return f"""return vector<string>({self.maybe(f"args, args + {self.size}")});"""
+
+    def __str__(self) -> str:
+        return dedent(
+            f"""\
+            {self.create_template_args()}
+            inline vector<string> vec_of_any({self.create_args(with_type=True)}) {{
+                {self.create_args_array()}
+                {self.create_return()}
+            }}
+            """
+        )
+
+
+@dataclass(frozen=True)
+class VecOfAny:
+    size: int = 10
+
+    @cached_property
+    def as_text(self) -> str:
+        text = "\n".join([str(Template(n)) for n in range(self.size + 1)])
+        return template.format(text=text)
+
+    def __repr__(self) -> str:
+        return self.as_text
+
+
+def create_formatted_result(size: int, path: Path | None) -> str:
+    text = VecOfAny(size).as_text
+    if path:
+        text = wrap_header(text, path)
+    if shutil.which("clang-format"):
+        text = clang_format(text)
+
+    return text + "\n"
+
+
+def main():
+    from docopt import docopt
+
+    assert __doc__ is not None
+    args: dict[str, str] = docopt(__doc__)
+
+    # print(args)
+
+    size = int(args["--size"])
+    path = Path(args["<path>"]) if args["<path>"] else None
+    text = create_formatted_result(size, path)
+
+    if args["--dry"]:
+        print(text)
+    elif path is not None:
+        path.write_text(text)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## 개요

<!--
풀 리퀘스트에 이슈 연결하기
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- Fixes #102
- Resolved #101
-->

- Resolves #38 

## 설명

```c++
#include "util/strutil/strutil.hpp"
int main() {
  using namespace std;

  int foo = 123;
  string bar = "world";
  int result = 3;

  cout << FMT("{foo} {} {{}}", (foo, bar, result)) << endl;
}
// 123 world {}
```
