### PR TITLE
받은 데이터를 prefix, command, params 부분으로 파싱 (Issue39)

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,17 @@
+{
+  "configurations": [
+    {
+      "name": "(lldb) Launch",
+      "type": "cppdbg",
+      "request": "launch",
+      "program": "${workspaceFolder}/ircserv",
+      "args": [],
+      "stopAtEntry": false,
+      "cwd": "${workspaceFolder}",
+      "environment": [],
+      "externalConsole": false,
+      "MIMode": "lldb",
+      "preLaunchTask": "make all"
+    }
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,17 @@
+{
+  // See https://go.microsoft.com/fwlink/?LinkId=733558
+  // for the documentation about the tasks.json format
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "make all",
+      "type": "process",
+      "command": "/usr/bin/make",
+      "args": ["all"],
+      "group":{
+        "kind": "build",
+        "isDefault": true
+      }
+    }
+  ]
+}

--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -14,6 +14,9 @@
 #include "event/event.hpp"
 #include "socket/socket.hpp"
 #include "util/FixedBuffer/FixedBuffer.hpp"
+#include "util/strutil/strutil.hpp"
+#include "util/LazyString/LazyString.hpp"
+#include "util/irctype/irctype.hpp"
 
 Client::Client(int sock, Server &server, ClientList::iterator this_position)
     : sock_(sock), server_(server), this_position_(this_position) {}
@@ -25,119 +28,19 @@ Client::~Client() {
 
 int Client::getFd() const { return sock_; }
 
-namespace tt {
-bool isLetter(char c) { return std::isalpha(c); }
-
-bool isDigit(char c) { return std::isdigit(c); }
-
-bool isSeprator(char c) { return c == ':' || c == ' '; }
-
-bool isSpecial(char c) { return c == '\r' || c == '\n' || c == '\0'; }
-
-bool isNospcrlfcl(char c) { return !isSeprator(c) && !isSpecial(c); }
-
-struct LazyString {
-  char *start;
-  char *end;
-  std::string str;
-  void append() {
-    if (start && end) {
-      str.append(start, end);
-      start = NULL;
-      end = NULL;
-    }
-  }
-};
-
-struct ParserResult {
-  enum e { kContinue, kSuccess, kFailure };
-};
-
-struct ParserState {
-  enum e { kBegin, kPrefix, kCommand, kTrailing, kParam, kParamStart, kLf };
-};
-
-class IRCParser {
- public:
-  IRCParser() : state_(ParserState::kBegin), length_(0) {}
-  ParserResult::e parse(Buffer &buffer) {
-    while (!buffer.eof()) {
-      ++length_;
-      if (length_ > 512) {
-        return ParserResult::kFailure;
-      }
-      char ch = buffer.peek();
-      switch (state_) {
-        case ParserState::kBegin:
-          if (ch == ':') {
-            state_ = ParserState::kPrefix;
-            prefix_.start = buffer.data() + buffer.tellg();
-          } else if (isLetter(ch) || isDigit(ch)) {
-            state_ = ParserState::kCommand;
-            command_.start = buffer.data() + buffer.tellg();
-          } else {
-            return ParserResult::kFailure;
-          }
-          break;
-        case ParserState::kPrefix:
-          if (ch == ' ') {
-            prefix_.end = buffer.data() + buffer.tellg();
-            prefix_.append();
-            state_ = ParserState::kCommand;
-          }
-          break;
-        case ParserState::kCommand:
-          if (ch == ' ' || ch == '\r') {
-            command_.end = buffer.data() + buffer.tellg();
-            command_.append();
-            if (ch == ' ') {
-              state_ = ParserState::kParamStart;
-            } else {
-              state_ = ParserState::kLf;
-            }
-          } else if (!isLetter(ch) && !isDigit(ch)) {
-            return ParserResult::kFailure;
-          }
-          break;
-        case ParserState::kParam:
-          if (ch == ' ')
-            break;
-        case ParserState::kParamStart:
-          if (isNosp)
-            params_.push_back(LazyString());
-          params_.back().start = buffer.data() + buffer.tellg();
-
-          break;
-        case ParserState::kLf:
-          if (ch == '\n') {
-            return ParserResult::kSuccess;
-          } else {
-            return ParserResult::kFailure;
-          }
-      }
-      buffer.pop();
-    }
-
-    if (buffer.eof()) {
-    }
-  }
-  LazyString prefix_;
-  LazyString command_;
-  std::vector<LazyString> params_;
-  ParserState::e state_;
-  std::size_t length_;
-};
-
-int parse() {}
-}  // namespace tt
-
 void Client::handleReadEvent(Event &e) {
   if (e.data != 0) {
-    std::cout << "-recv: " << e.data << std::endl;
     ssize_t len = recv(e.data);
     if (len > 0) {
-      // parse while (!buffer.eof()) { std::cout << buffer.pop(); }
-      std::cout << std::endl;
+      ParserResult::e result = parser_.parse(buffer_);
+      if (result == ParserResult::kFailure) {
+        parser_.clear();
+        std::cout << "Failed to parse message" << std::endl;
+        // XXX log
+      } else if (result == ParserResult::kSuccess) {
+        parser_.clear();
+        std::cout << "Parse Success" << std::endl;
+      }
     }
   }
   if ((e.flags.test(EventFlag::kEOF)) || e.data == 0) {
@@ -162,10 +65,10 @@ int Client::handle(Event e) {
 int Client::close() { return ::close(sock_); }
 
 ssize_t Client::recv(size_t length) {
-  ssize_t ret = util::recv(sock_, buffer.begin(), length);
+  ssize_t ret = util::recv(sock_, buffer_.begin(), length);
   if (ret == -1)
     return ret;
-  buffer.seekg(0);
-  buffer.seekp(ret);
+  buffer_.seekg(0);
+  buffer_.seekp(ret);
   return ret;
 }

--- a/src/Client.hpp
+++ b/src/Client.hpp
@@ -5,12 +5,12 @@
 
 #include "event/event.hpp"
 #include "util/FixedBuffer/FixedBuffer.hpp"
+#include "IRCParser.hpp"
 
 class Server;
 class Client;
 
 typedef std::list<Client *> ClientList;
-typedef util::FixedBuffer<char, 512> Buffer;
 
 class Client : public IEventHandler {
  public:
@@ -35,7 +35,8 @@ class Client : public IEventHandler {
   void handleReadEvent(Event &e);
 
  private:
-  Buffer buffer;
+  util::Buffer buffer_;
+  IRCParser parser_;
   int sock_;
   Server &server_;
   ClientList::iterator this_position_;

--- a/src/IRCParser.cpp
+++ b/src/IRCParser.cpp
@@ -1,0 +1,188 @@
+#include "IRCParser.hpp"
+
+#include "util/irctype/irctype.hpp"
+
+IRCParser::IRCParser() : state_(ParserState::kBegin), length_(0) {}
+
+ParserResult::e IRCParser::parseBegin(util::Buffer &buffer, char ch) {
+  if (ch == ':') {
+    state_ = ParserState::kPrefix;
+    msg_.prefix.setStart(buffer.data() + buffer.tellg());
+  } else if (util::isLetter(ch) || util::isDigit(ch)) {
+    state_ = ParserState::kCommand;
+    msg_.command.setStart(buffer.data() + buffer.tellg());
+  } else {
+    return ParserResult::kFailure;
+  }
+  return ParserResult::kSuccess;
+}
+
+ParserResult::e IRCParser::parsePrefix(util::Buffer &buffer, char ch) {
+  if (ch == ' ') {
+    msg_.prefix.setEnd(buffer.data() + buffer.tellg());
+    msg_.prefix.apply();
+    state_ = ParserState::kCommand;
+  }
+  return ParserResult::kSuccess;
+}
+
+ParserResult::e IRCParser::parseCommand(util::Buffer &buffer, char ch) {
+  if (ch == ' ') {
+    msg_.command.setEnd(buffer.data() + buffer.tellg());
+    msg_.command.apply();
+    state_ = ParserState::kParamStart;
+  } else if (ch == '\r') {
+    msg_.command.setEnd(buffer.data() + buffer.tellg());
+    msg_.command.apply();
+    state_ = ParserState::kLF;
+  } else if (!util::isLetter(ch) && !util::isDigit(ch)) {
+    return ParserResult::kFailure;
+  }
+  return ParserResult::kSuccess;
+}
+
+ParserResult::e IRCParser::parseParamStart(util::Buffer &buffer, char ch) {
+  if (ch == ':') {
+    state_ = ParserState::kTrailingStart;
+  } else if (util::isRegular(ch)) {
+    state_ = ParserState::kParam;
+    msg_.params.push_back(util::LazyString());
+    msg_.params.back().setStart(buffer.data() + buffer.tellg());
+  } else {
+    return ParserResult::kFailure;
+  }
+  return ParserResult::kSuccess;
+}
+
+ParserResult::e IRCParser::parseParam(util::Buffer &buffer, char ch) {
+  switch (ch) {
+    case ' ':
+      msg_.params.back().setEnd(buffer.data() + buffer.tellg());
+      msg_.params.back().apply();
+      state_ = ParserState::kParamStart;
+      break;
+
+    case '\r':
+      msg_.params.back().setEnd(buffer.data() + buffer.tellg());
+      msg_.params.back().apply();
+      state_ = ParserState::kLF;
+      break;
+
+    case '\n':
+    case '\0':
+      return ParserResult::kFailure;
+      break;
+
+    default:
+      break;
+  }
+  return ParserResult::kSuccess;
+}
+
+ParserResult::e IRCParser::parseTrailingStart(util::Buffer &buffer, char ch) {
+  msg_.params.push_back(util::LazyString());
+  switch (ch) {
+    case '\r':
+      state_ = ParserState::kLF;
+      break;
+
+    case '\0':
+    case '\n':
+      return ParserResult::kFailure;
+      break;
+    default:
+      msg_.params.back().setStart(buffer.data() + buffer.tellg());
+      state_ = ParserState::kTrailing;
+  }
+  return ParserResult::kSuccess;
+}
+
+ParserResult::e IRCParser::parseTrailing(util::Buffer &buffer, char ch) {
+  switch (ch) {
+    case '\r':
+      msg_.params.back().setEnd(buffer.data() + buffer.tellg());
+      msg_.params.back().apply();
+      state_ = ParserState::kLF;
+      break;
+    case '\0':
+    case '\n':
+      return ParserResult::kFailure;
+      break;
+    default:
+      break;
+  }
+  return ParserResult::kSuccess;
+}
+
+ParserResult::e IRCParser::parseLF(char ch) {
+  if (ch == '\n') {
+    return ParserResult::kSuccess;
+  } else {
+    return ParserResult::kFailure;
+  }
+}
+
+ParserResult::e IRCParser::parse(util::Buffer &buffer) {
+  while (!buffer.eof()) {
+    ++length_;
+    if (length_ > 512) {
+      return ParserResult::kFailure;
+    }
+    char ch = buffer.peek();
+    switch (state_) {
+      case ParserState::kBegin:
+        if (parseBegin(buffer, ch) == ParserResult::kFailure)
+          return ParserResult::kFailure;
+        break;
+      case ParserState::kPrefix:
+        if (parsePrefix(buffer, ch) == ParserResult::kFailure)
+          return ParserResult::kFailure;
+        break;
+      case ParserState::kCommand:
+        if (parseCommand(buffer, ch) == ParserResult::kFailure)
+          return ParserResult::kFailure;
+        break;
+      case ParserState::kParamStart:
+        if (parseParamStart(buffer, ch) == ParserResult::kFailure)
+          return ParserResult::kFailure;
+        break;
+      case ParserState::kParam:
+        if (parseParam(buffer, ch) == ParserResult::kFailure)
+          return ParserResult::kFailure;
+        break;
+      case ParserState::kTrailingStart:
+        if (parseTrailingStart(buffer, ch) == ParserResult::kFailure)
+          return ParserResult::kFailure;
+        break;
+      case ParserState::kTrailing:
+        if (parseTrailing(buffer, ch) == ParserResult::kFailure)
+          return ParserResult::kFailure;
+        break;
+      case ParserState::kLF:
+        return parseLF(ch);
+        break;
+      default:
+        return ParserResult::kFailure;
+    }
+    buffer.pop();
+  }
+  msg_.prefix.apply();
+  msg_.command.apply();
+  if (!msg_.params.empty())
+    msg_.params.back().apply();
+  return ParserResult::kContinue;
+}
+
+void IRCParser::clearMessage() {
+  msg_.clear();
+}
+
+void IRCParser::clearState() {
+  state_ = ParserState::kBegin;
+  length_ = 0;
+}
+
+void IRCParser::clear() {
+  clearMessage();
+  clearState();
+}

--- a/src/IRCParser.cpp
+++ b/src/IRCParser.cpp
@@ -8,6 +8,8 @@ ParserResult::e IRCParser::parseBegin(util::Buffer &buffer, char ch) {
   if (ch == ':') {
     state_ = ParserState::kPrefix;
     msg_.prefix.setStart(buffer.data() + buffer.tellg());
+  } else if (ch == '\r') {
+    state_ = ParserState::kEmptyLF;
   } else if (util::isLetter(ch) || util::isDigit(ch)) {
     state_ = ParserState::kCommand;
     msg_.command.setStart(buffer.data() + buffer.tellg());
@@ -160,6 +162,11 @@ ParserResult::e IRCParser::parse(util::Buffer &buffer) {
         break;
       case ParserState::kLF:
         return parseLF(ch);
+        break;
+      case ParserState::kEmptyLF:
+        if (parseLF(ch) == ParserResult::kFailure)
+          return ParserResult::kFailure;
+        clear();
         break;
       default:
         return ParserResult::kFailure;

--- a/src/IRCParser.hpp
+++ b/src/IRCParser.hpp
@@ -1,0 +1,69 @@
+#ifndef IRCPARSER_HPP
+#define IRCPARSER_HPP
+
+#include <vector>
+
+#include "util/FixedBuffer/FixedBuffer.hpp"
+#include "util/LazyString/LazyString.hpp"
+
+struct ParserResult {
+  enum e { kContinue, kSuccess, kFailure };
+};
+
+struct ParserState {
+  enum e {
+    kBegin,
+    kPrefix,
+    kCommand,
+    kParamStart,
+    kParam,
+    kTrailingStart,
+    kTrailing,
+    kLF
+  };
+};
+
+struct Message {
+  void clear() {
+    prefix.clear();
+    command.clear();
+    params.clear();
+  }
+  util::LazyString prefix;
+  util::LazyString command;
+  std::vector<util::LazyString> params;
+};
+
+class IRCParser {
+ public:
+  IRCParser();
+  // ~IRCParser() = default;
+
+ private:
+  IRCParser(const IRCParser &);             // = delete;
+  IRCParser &operator=(const IRCParser &);  // = delete;
+
+ public:
+  ParserResult::e parse(util::Buffer &buffer);
+  void clearMessage();
+  void clearState();
+  void clear();
+  const Message &getMessage();
+
+ private:
+  ParserResult::e parseBegin(util::Buffer &buffer, char ch);
+  ParserResult::e parsePrefix(util::Buffer &buffer, char ch);
+  ParserResult::e parseCommand(util::Buffer &buffer, char ch);
+  ParserResult::e parseParamStart(util::Buffer &buffer, char ch);
+  ParserResult::e parseParam(util::Buffer &buffer, char ch);
+  ParserResult::e parseTrailingStart(util::Buffer &buffer, char ch);
+  ParserResult::e parseTrailing(util::Buffer &buffer, char ch);
+  ParserResult::e parseLF(char ch);
+
+ private:
+  Message msg_;
+  ParserState::e state_;
+  std::size_t length_;
+};
+
+#endif  // IRCPARSER_HPP

--- a/src/IRCParser.hpp
+++ b/src/IRCParser.hpp
@@ -19,7 +19,8 @@ struct ParserState {
     kParam,
     kTrailingStart,
     kTrailing,
-    kLF
+    kLF,
+    kEmptyLF
   };
 };
 

--- a/src/Server.hpp
+++ b/src/Server.hpp
@@ -10,7 +10,6 @@ class Server;
 class Client;
 
 typedef std::list<Client *> ClientList;
-typedef util::FixedBuffer<char, 512> Buffer;
 
 class Server : public IEventHandler {
  public:

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -19,7 +19,7 @@
 #include "socket/socket.hpp"
 #include "util/FixedBuffer/FixedBuffer.hpp"
 
-const static char *bind_addr = "127.0.0.1";
+const static char *bind_addr = "10.11.1.5";
 const static int port = 7778;
 
 static sig_atomic_t recived_sig;

--- a/src/util/FixedBuffer/FixedBuffer.hpp
+++ b/src/util/FixedBuffer/FixedBuffer.hpp
@@ -34,6 +34,8 @@ class FixedBuffer : public array<T, buffer_size> {
   std::size_t o_cursor_;
 };
 
+typedef util::FixedBuffer<char, 512> Buffer;
+
 }  // namespace util
 
 #include "FixedBuffer.tpp"

--- a/src/util/LazyString/LazyString.cpp
+++ b/src/util/LazyString/LazyString.cpp
@@ -4,6 +4,12 @@ namespace util {
 
 LazyString::LazyString() : start_(NULL), end_(NULL) {}
 
+void LazyString::clear() {
+  std::string::clear();
+  start_ = NULL;
+  end_ = NULL;
+}
+
 void LazyString::apply() {
   if (start_ && end_) {
     append(start_, end_);
@@ -16,4 +22,4 @@ void LazyString::setStart(const char *start) { start_ = start; }
 
 void LazyString::setEnd(const char *end) { end_ = end; }
 
-}
+}  // namespace util

--- a/src/util/LazyString/LazyString.cpp
+++ b/src/util/LazyString/LazyString.cpp
@@ -1,0 +1,19 @@
+#include "LazyString.hpp"
+
+namespace util {
+
+LazyString::LazyString() : start_(NULL), end_(NULL) {}
+
+void LazyString::apply() {
+  if (start_ && end_) {
+    append(start_, end_);
+    start_ = NULL;
+    end_ = NULL;
+  }
+}
+
+void LazyString::setStart(const char *start) { start_ = start; }
+
+void LazyString::setEnd(const char *end) { end_ = end; }
+
+}

--- a/src/util/LazyString/LazyString.hpp
+++ b/src/util/LazyString/LazyString.hpp
@@ -9,7 +9,7 @@ namespace util {
  * @brief apply()를 하기 전까지는 문자열의 포인터만 가지고 있다가
  *        apply()를 하는 순간 실제 string으로 적용해주는 클래스
  */
-class LazyString : std::string {
+class LazyString : public std::string {
  public:
   /**
    * @brief 새로운 빈 LazyString을 생성한다
@@ -22,6 +22,11 @@ class LazyString : std::string {
 
  public:
   /**
+   * @brief 문자열을 초기화한다
+   */
+  void clear();
+
+  /**
    * @brief 만약 start와 end의 값이 설정되어 있다면,
    * 현재 문자열 맨 뒤에 [start, end)범위의 문자열을 덧붙인다.
    */
@@ -32,14 +37,14 @@ class LazyString : std::string {
    *
    * @param start 문자열 포인터
    */
-  void setStart(const char *start) { start_ = start; }
+  void setStart(const char *start);
 
   /**
    * @brief 추가할 문자열의 끝 다음 부분을 지정한다.
    *
    * @param end 문자열 포인터
    */
-  void setEnd(const char *end) { end_ = end; }
+  void setEnd(const char *end);
 
  private:
   const char *start_;

--- a/src/util/LazyString/LazyString.hpp
+++ b/src/util/LazyString/LazyString.hpp
@@ -1,0 +1,51 @@
+#ifndef UTIL_LAZYSTRING_HPP
+#define UTIL_LAZYSTRING_HPP
+
+#include <string>
+
+namespace util {
+
+/**
+ * @brief apply()를 하기 전까지는 문자열의 포인터만 가지고 있다가
+ *        apply()를 하는 순간 실제 string으로 적용해주는 클래스
+ */
+class LazyString : std::string {
+ public:
+  /**
+   * @brief 새로운 빈 LazyString을 생성한다
+   */
+  LazyString();
+
+  // LazyString &operator=(const LazyString &) = default
+  // LazyString (const LazyString &) = default
+  // ~LazyString() = default
+
+ public:
+  /**
+   * @brief 만약 start와 end의 값이 설정되어 있다면,
+   * 현재 문자열 맨 뒤에 [start, end)범위의 문자열을 덧붙인다.
+   */
+  void apply();
+
+  /**
+   * @brief 추가할 문자열의 시작 부분을 지정한다.
+   *
+   * @param start 문자열 포인터
+   */
+  void setStart(const char *start) { start_ = start; }
+
+  /**
+   * @brief 추가할 문자열의 끝 다음 부분을 지정한다.
+   *
+   * @param end 문자열 포인터
+   */
+  void setEnd(const char *end) { end_ = end; }
+
+ private:
+  const char *start_;
+  const char *end_;
+};
+
+}  // namespace util
+
+#endif  // UTIL_LAZYSTRING_HPP

--- a/src/util/irctype/irctype.cpp
+++ b/src/util/irctype/irctype.cpp
@@ -1,0 +1,15 @@
+#include <cctype>
+
+namespace util {
+
+bool isLetter(char c) { return std::isalpha(c); }
+
+bool isDigit(char c) { return std::isdigit(c); }
+
+bool isSeprator(char c) { return c == ':' || c == ' '; }
+
+bool isSpecial(char c) { return c == '\r' || c == '\n' || c == '\0'; }
+
+bool isNospcrlfcl(char c) { return !isSeprator(c) && !isSpecial(c); }
+
+}  // namespace util

--- a/src/util/irctype/irctype.cpp
+++ b/src/util/irctype/irctype.cpp
@@ -10,6 +10,6 @@ bool isSeprator(char c) { return c == ':' || c == ' '; }
 
 bool isSpecial(char c) { return c == '\r' || c == '\n' || c == '\0'; }
 
-bool isNospcrlfcl(char c) { return !isSeprator(c) && !isSpecial(c); }
+bool isRegular(char c) { return !isSeprator(c) && !isSpecial(c); }
 
 }  // namespace util

--- a/src/util/irctype/irctype.hpp
+++ b/src/util/irctype/irctype.hpp
@@ -1,6 +1,8 @@
 #ifndef UTIL_IRCTYPE_HPP
 #define UTIL_IRCTYPE_HPP
 
+namespace util {
+
 /**
  * @brief [A-Za-z]
  */
@@ -30,5 +32,7 @@ bool isSpecial(char c);
  *  ' '   (space)
  */
 bool isRegular(char c);
+
+}
 
 #endif  // UTIL_IRCTYPE_HPP

--- a/src/util/irctype/irctype.hpp
+++ b/src/util/irctype/irctype.hpp
@@ -1,0 +1,34 @@
+#ifndef UTIL_IRCTYPE_HPP
+#define UTIL_IRCTYPE_HPP
+
+/**
+ * @brief [A-Za-z]
+ */
+bool isLetter(char c);
+
+/**
+ * @brief [0-9]
+ */
+bool isDigit(char c);
+
+/**
+ * @brief ':'(colon) or ' '(space)
+ */
+bool isSeprator(char c);
+
+/**
+ * @brief '\\r'(CR) or '\\n'(LF) or '\\0'(NUL)
+ */
+bool isSpecial(char c);
+
+/**
+ * @brief every character except
+ *  '\\r' (CR),
+ *  '\\n' (LF),
+ *  '\\0' (NUL),
+ *  ':'   (colon),
+ *  ' '   (space)
+ */
+bool isRegular(char c);
+
+#endif  // UTIL_IRCTYPE_HPP


### PR DESCRIPTION
## 개요

<!--
풀 리퀘스트에 이슈 연결하기
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- Fixes #102
- Resolved #101
-->

- Resolved #39

## 설명

받은 raw 바이트열을 IRC메시지의 기본 구성 요소인 prefix, command, parameters부분으로 파싱하는것을 구현함

<!--
무엇이 변했는지 적기
-->
