### PR TITLE
소멸자 호출 순서를 수정함

### DIFF
--- a/src/server/Server.cpp
+++ b/src/server/Server.cpp
@@ -24,11 +24,11 @@ Server::~Server() {
        it != end; ++it) {
     delete *it;
   }
-  for (ChannelMap::iterator it = channels_.begin(), end = channels_.end();
+  for (ClientMap::iterator it = clients_.begin(), end = clients_.end();
        it != end; ++it) {
     delete it->second;
   }
-  for (ClientMap::iterator it = clients_.begin(), end = clients_.end();
+  for (ChannelMap::iterator it = channels_.begin(), end = channels_.end();
        it != end; ++it) {
     delete it->second;
   }


### PR DESCRIPTION
## 개요

<!--
풀 리퀘스트에 이슈 연결하기
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- Fixes #102
- Resolved #101
-->

- Fixes #92 

## 설명

<!--
무엇이 변했는지 적기
-->
클라이언트가 먼저 소멸되고(소멸 과정에서 채널 목록 참조)  이후에 채널이 소멸되게 함