### PR TITLE
호스트네임을 ip주소로 설정

### DIFF
--- a/src/client/Client.cpp
+++ b/src/client/Client.cpp
@@ -38,7 +38,7 @@ const Client::CmdMap Client::map_after_register_ =
         p("PONG", &Client::pong));
 /*CLIENT===============================*/
 
-Client::Client(int sock, ClientList::iterator pos)
+Client::Client(int sock, struct sockaddr_in addr, ClientList::iterator pos)
     : map_(&map_before_register_),
       sock_(sock),
       pos_(pos),
@@ -46,6 +46,7 @@ Client::Client(int sock, ClientList::iterator pos)
       conn_state_(ConnState::kClear) {
   addEvent(EventKind::kRead);
   server.getPool().addTimer(TimerKind::kRegister, this, server.config_.timeout);
+  ident_.addr_ = addr;
 }
 
 Client::~Client() {
@@ -500,7 +501,11 @@ result_t::e Client::registerUser(const Message &m) {
   }
 
   ident_.username_ = m.params[0];
-  ident_.hostname_ = m.params[1];
+
+  // TODO rDNS 쿼리로 검증
+  // ident_.hostname_ = m.params[1];
+  ident_.hostname_ = inet_ntoa(ident_.addr_.sin_addr);
+
   ident_.servername_ = m.params[2];
   ident_.realname_ = m.params[3];
 

--- a/src/client/Client.hpp
+++ b/src/client/Client.hpp
@@ -56,7 +56,7 @@ struct ConnState {
 
 class Client : public IEventHandler {
  public:
-  Client(int sock, ClientList::iterator pos);
+  Client(int sock, struct sockaddr_in addr, ClientList::iterator pos);
 
   virtual ~Client();
 

--- a/src/server/Server.cpp
+++ b/src/server/Server.cpp
@@ -88,7 +88,7 @@ result_t::e Server::handle(Event e) {
     ClientList::iterator entry =
         unregistered_clients_.insert(unregistered_clients_.end(), NULL);
 
-    *entry = new Client(client_socket, entry);
+    *entry = new Client(client_socket, sin, entry);
     return result_t::kOK;
   } else {
     return result_t::kError;  // unknown event


### PR DESCRIPTION
## 개요

<!--
풀 리퀘스트에 이슈 연결하기
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- Fixes #102
- Resolved #101
-->

- Resolved #103 

## 설명

사용자가 처음 서버에 접속할 때 USER 명령어를 사용하는데, 이때 2번째 필드가 사용자의 호스트가 된다. 하지만, 이 필드는 유저가 직접 입력할 수 있는 부분이기 때문에 검증이 필요하다.

실제로 inspircd에서도 처음 연결 과정에서 lookup... 같은 안내창이 나오면서 사용자의 ip와 호스트가 대응되는지 확인하려고 DNS서버에 요청을 보낸다.

이때 reverse DNS 요청으로 [주어진 ip ==> ip와 연결된 호스트] 변환을 한 뒤 입력된 호스트와 비교하는 방법과
       일반적인 DNS 요청으로 [입력된 호스트 ==> 호스트와 연결된 ip] 변환을 한 뒤 ip가 일치하는지 비교하는 방법이 있을 거라고 생각했는데

inspircd에서는 어떤 방식으로 구현했는지 궁금해서 strace를 사용해서 시스템 콜을 추적했다.
그 결과 sendto() 시스템 콜로 (주로 UDP 연결에 사용) '??????????in_addr.arpa' 쪽으로 요청을 보내는 것을 확인했고, 이 주소는 rDNS 요청을 보낼 때 사용하는 주소이다.

따라서 rDNS를 이용해서 구현하려고 했으나, 관련된 함수인 getnameinfo(3) 을 사용하면 비용이 매우 비싼 DNS요청을 블로킹되면서 처리해야 한다는 큰 단점이 있고, 직접 처리하기에는 너무 복잡해서 일단은 사용자의 입력으로 들어오는 호스트는 무시하고 ip 주소를 직접 이용하기로 했다

<!--
무엇이 변했는지 적기
-->
