### PR TITLE
segfault 일으키는 스크립트

### DIFF
--- a/connect.py
+++ b/connect.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+
+import logging
+import socket
+import time
+from dataclasses import dataclass, field
+from enum import Enum
+from textwrap import dedent
+from typing import ClassVar
+
+logging.basicConfig(level=logging.NOTSET)
+
+
+class Config(Enum):
+    host = socket.gethostname()
+    port = 6667
+    serverName = "excitingirc"
+
+
+def create_socket() -> socket.socket:
+    "소켓을 만들고 연결해서 돌려주기"
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.connect((Config.host.value, Config.port.value))
+    return sock
+
+
+def send_and_recieve(sock: socket.socket, msg: bytes) -> bytes:
+    "소켓에 메시지를 보내고 받아서 돌려주기"
+    sock.sendall(msg)
+    logging.info(f"sent {msg = }")
+    result = sock.recv(1024)
+    logging.info(f"received {result = }")
+    return result
+
+
+@dataclass
+class Client:
+    no: ClassVar[int] = 0
+    name: str = field(init=False)
+    sock: socket.socket = field(init=False, default_factory=create_socket)
+
+    def __post_init__(self):
+        self.name = f"user{Client.no:02}"
+        Client.no += 1
+
+    def connect(self):
+        self.send(
+            dedent(
+                f"""\
+                PASS :password\r
+                NICK {self.name}\r
+                USER user user localhost :longusername\r
+                """
+            )
+        )
+
+    def send(self, msg: str | bytes) -> str:
+        if isinstance(msg, str):
+            if not msg.endswith("\r\n"):
+                msg += "\r\n"
+            msg = msg.encode()
+
+        return send_and_recieve(self.sock, msg).decode()
+
+
+def main() -> None:
+    client = Client()
+    client.connect()
+    client.send(f"PING :{Config.serverName.value}\r\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/connect.py
+++ b/connect.py
@@ -14,7 +14,7 @@ logging.basicConfig(level=logging.NOTSET)
 class Config(Enum):
     host = socket.gethostname()
     port = 6667
-    serverName = "excitingirc"
+    serverName = "excitingirc"  # "penguin.omega.example.org"
 
 
 def create_socket() -> socket.socket:
@@ -47,9 +47,9 @@ class Client:
         self.send(
             dedent(
                 f"""\
-                PASS :password\r
+                PASS password\r
                 NICK {self.name}\r
-                USER user user localhost :longusername\r
+                USER youkim 0 * :Younghyun Kim\r
                 """
             )
         )
@@ -66,6 +66,7 @@ class Client:
 def main() -> None:
     client = Client()
     client.connect()
+    time.sleep(1)
     client.send(f"PING :{Config.serverName.value}\r\n")
 
 

--- a/segfault.sh
+++ b/segfault.sh
@@ -1,4 +1,8 @@
+trap "kill 0" SIGINT
+trap "kill 0" EXIT
+trap "exit" INT TERM
+
 while true; do
-  python3 connect.py || break
+  python3 connect.py &
   sleep 0.1
 done

--- a/segfault.sh
+++ b/segfault.sh
@@ -1,0 +1,4 @@
+while true; do
+  python3 connect.py || break
+  sleep 0.1
+done


### PR DESCRIPTION
## 개요
- Resolved #113 

## 설명
<img width="704" alt="image" src="https://user-images.githubusercontent.com/54838975/175931055-d1265cfc-f781-40e4-841e-f99f72f3f79b.png">

- `segfault.sh`는 0.1초마다 `connect.py`를 실행
- 위치: [EventPool.cpp](https://github.com/exciting-IRC/IRC/blob/d05d2118655c2fedd03d2bc8a0887ecff680ae19/src/event/EventPool.cpp#L162)
- 가능한 원인: 소켓이 어떠한 오류로 끊긴 상태에서 읽기를 시도

### inspircd에서
```c
Mon Jun 27 2022 20:54:20 core_dns: Using cached result
Mon Jun 27 2022 20:54:20 USERINPUT: C[422AAAAAC] I PASS password
Mon Jun 27 2022 20:54:20 USERINPUT: C[422AAAAAC] I NICK user00
Mon Jun 27 2022 20:54:20 USERINPUT: C[422AAAAAC] I USER youkim 0 * :youkim
Mon Jun 27 2022 20:54:20 USERINPUT: C[422AAAAAC] I PING :excitingirc
Mon Jun 27 2022 20:54:20 USEROUTPUT: C[422AAAAAC] O :penguin.omega.example.org 451 user00 PING :You have not registered.
Mon Jun 27 2022 20:54:20 SOCKET: Error on FD 8 - 'Connection closed'
Mon Jun 27 2022 20:54:20 USERS: QuitUser: 422AAAAAC=user00 'Connection closed'
Mon Jun 27 2022 20:54:20 USEROUTPUT: C[422AAAAAC] O ERROR :Closing link: (youkim@c1r1s3.42seoul.kr) [Connection closed]
Mon Jun 27 2022 20:54:20 SOCKET: DoWrite on errored or closed socket
Mon Jun 27 2022 20:54:20 SOCKET: Remove file descriptor: 8
Mon Jun 27 2022 20:54:20 CULLLIST: Deleting @0x7fb16e4040e0
```
- `segfault.sh`를 실행했을 시 로그, `connect.py`에서 받은 메시지: `INFO:root:received result = b':penguin.omega.example.org 451 user00 PING :You have not registered.\r\n'`
- `connect.py`에 1초 sleep을 추가해주었더니 `inspircd`와 `excitingirc` 모두 정상적으로 동작
```py
    client = Client()
    client.connect()
    time.sleep(1) # <- 추가됨
    client.send(f"PING :{Config.serverName.value}\r\n")
```